### PR TITLE
修复 偶数次搜索时无结果问题

### DIFF
--- a/src/main/kotlin/top/limbang/mirai/mcmod/service/MinecraftModService.kt
+++ b/src/main/kotlin/top/limbang/mirai/mcmod/service/MinecraftModService.kt
@@ -59,6 +59,10 @@ class MinecraftModService {
 
     fun getSearchResultsListSize() = searchResultsList.size
 
-    fun clear() = searchResultsList.clear()
+    fun clear() {
+        searchResultsList.clear()
+        page = 1
+        nextPage = false
+    }
 
 }


### PR DESCRIPTION
简单来说，就是上次的状态没有清理干净，直到下次搜索失败了才清理。