### PR TITLE
修复 当搜索结果中包含的图片地址为相对地址时，下载失败问题

### DIFF
--- a/src/main/kotlin/top/limbang/mirai/mcmod/service/MessageHandle.kt
+++ b/src/main/kotlin/top/limbang/mirai/mcmod/service/MessageHandle.kt
@@ -100,7 +100,10 @@ object MessageHandle {
         val imageExternalResource = if (file.exists()) {
             file.readBytes().toExternalResource()
         } else {
-            HttpUtil.downloadImage(url, file).toExternalResource()
+            val imgSrc = if (url.startsWith('/')) {
+                url = "https://www.mcmod.cn$url"
+            } else { url }
+            HttpUtil.downloadImage(imgSrc, file).toExternalResource()
         }
         val uploadImage = event.group.uploadImage(imageExternalResource)
         imageExternalResource.close()

--- a/src/main/kotlin/top/limbang/mirai/mcmod/service/MessageHandle.kt
+++ b/src/main/kotlin/top/limbang/mirai/mcmod/service/MessageHandle.kt
@@ -95,16 +95,14 @@ object MessageHandle {
      * 读取图片
      */
     private suspend fun readImage(url: String, event: GroupMessageEvent): Image {
-        val imgFileName = url.substringAfterLast("/").substringBefore("?")
-        val file = File("data/top.limbang.mirai-console-mcmod-plugin/img/$imgFileName")
-        val imageExternalResource = if (file.exists()) {
-            file.readBytes().toExternalResource()
+        val base64Prefix = "data:image/png;base64,"
+        val imageExternalResource = if (url.startsWith(base64Prefix)) { // 处理base64情况
+            Base64.getDecoder().decode(url.substring(base64Prefix.length)).toExternalResource()
         } else {
-            val base64Prefix = "data:image/png;base64,"
-            if (url.startsWith(base64Prefix)) { // 处理base64情况
-                val decodedBytes = Base64.getDecoder().decode(url.substring(base64Prefix.length))
-                file.writeBytes(decodedBytes)
-                decodedBytes.toExternalResource()
+            val imgFileName = url.substringAfterLast("/").substringBefore("?")
+            val file = File("data/top.limbang.mirai-console-mcmod-plugin/img/$imgFileName")
+            if (file.exists()) {
+                file.readBytes().toExternalResource()
             } else {
                 HttpUtil.downloadImage(when {
                     url.startsWith("//") -> "https:$url" // 处理双斜杠开头情况"//i.mcmod.cn/..."


### PR DESCRIPTION
复现方式：搜索教程'星辉'，选第一个。
教程里面有一个表情包，src就是以/开头，是一个相对路径。
解决方案就是判断若url以/开始，就拼一段mcmod地址上去。