### PR TITLE
补充信息：将 mcmod 上的“相关链接”展示出来

### DIFF
--- a/src/main/kotlin/top/limbang/mcmod/mirai/utils/MessageUtils.kt
+++ b/src/main/kotlin/top/limbang/mcmod/mirai/utils/MessageUtils.kt
@@ -59,7 +59,8 @@ suspend fun Module.toMessage(event: MessageEvent, originalUrl: String) = with(ev
             }
         }
         bot says introductionToMessage(introduction)
-        if (isShowOriginalUrlEnabled) bot says "原文链接:$originalUrl"
+        if (isShowOriginalUrlEnabled)
+            bot says ("原文链接: $originalUrl\n" + commonLinks.joinToString("\n"))
     }
 }
 

--- a/src/main/kotlin/top/limbang/mcmod/network/model/Module.kt
+++ b/src/main/kotlin/top/limbang/mcmod/network/model/Module.kt
@@ -24,7 +24,8 @@ data class Module(
     val mainName: String,
     val secondaryName: String,
     val entity: List<Entity>,
-    val introduction: String
+    val introduction: String,
+    val commonLinks: List<String> = emptyList()
 ) {
     /**
      * ### 作者或开发团队


### PR DESCRIPTION
期望：方便开发、汉化、服务器管理员跳转相关页面
在此基础上，我想建议把相关链接紧跟在作者&团队后。因为 mod 资料比较长的时候要滑好一会滚鼠才能看到链接；而相关链接并不会很长