### PR TITLE
新增 WebP 图片支持

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "top.limbang.mcmod"
-version = "2.0.10"
+version = "2.1.0"
 
 repositories {
     maven("https://maven.aliyun.com/repository/public")
@@ -18,6 +18,9 @@ dependencies{
     implementation("org.jsoup:jsoup:1.15.4")
     implementation("com.squareup.retrofit2:retrofit:2.10.0")
     implementation("com.squareup.okhttp3:okhttp:5.0.0-alpha.11")
+    
+    // https://mvnrepository.com/artifact/org.sejda.imageio/webp-imageio
+    implementation("org.sejda.imageio:webp-imageio:0.1.6")
 
     testImplementation(kotlin("test"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")

--- a/src/main/kotlin/Mcmod.kt
+++ b/src/main/kotlin/Mcmod.kt
@@ -39,7 +39,7 @@ import top.limbang.mcmod.service.MiraiToMcmodService.toMcmodSearch
 object Mcmod : KotlinPlugin(JvmPluginDescription(
     id = "top.limbang.mcmod",
     name = "Mcmod",
-    version = "2.0.10",
+    version = "2.1.0",
 ) {
     author("limbang")
     info("""mc百科查询""")


### PR DESCRIPTION
通过添加 WebP 解码器以支持越来越多的 WebP 图片，将其转为 png 格式进行保存。

_修改了插件版本号到2.1.0_

关联issue #38